### PR TITLE
replace '.' with '_' in environment variables

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -860,7 +860,8 @@ func (f *FlagSet) ParseEnv(environ []string) error {
 			envKey = f.envPrefix + "_" + envKey
 		}
 		envKey = strings.Replace(envKey, "-", "_", -1)
-
+		envKey = strings.Replace(envKey, ".", "_", -1)
+		
 		value, isSet := env[envKey]
 		if !isSet {
 			continue


### PR DESCRIPTION
config keys like

```
user.name
user.email
```

should become

```
USER_NAME
USER_EMAIL
```
